### PR TITLE
fixed the moving algorithm

### DIFF
--- a/exa_logic.py
+++ b/exa_logic.py
@@ -410,8 +410,8 @@ class Game(object):
             else:
                 cards_move = self.stacks[i].resolve_move_from(0)
 
-            y_offset_pre = len(self.stacks[i].stack) - len(cards_move)
-            y_offset_post = max(0, len(self.stacks[j].stack) - 1)
+            y_offset_pre = len(self.stacks[i].stack)
+            y_offset_post = len(self.stacks[j].stack)
 
             # The text we're going to print
             unlock_text = ""


### PR DESCRIPTION
The `resolve_move_from` already modifies the pre stack, so a simple `length` is enough.
(we want to grab the card which place is the first empty place after the move)

As for the post stack, we want to drop the card in the first empty place, which is
exactly the `length` of the array (since the index is zero based),